### PR TITLE
Rebuild with OpenSSL 3 [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+aggregate_branch: openssl3_builds
+
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-aggregate_branch: openssl3_builds
-
-build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,9 @@ about:
     license: BSD-3-Clause
     license_family: BSD 
     license_file: COPYRIGHT
-    summary: OpenResty® is a dynamic web platform based on NGINX and LuaJIT.
+    summary: OpenResty is a dynamic web platform based on NGINX and LuaJIT.
     description: >
-      OpenResty® is a full-fledged web platform that integrates our enhanced version
+      OpenResty is a full-fledged web platform that integrates our enhanced version
       of the Nginx core, our enhanced version of LuaJIT, many carefully written Lua
       libraries, lots of high quality 3rd-party Nginx modules, and most of their external
       dependencies. It is designed to help developers easily build scalable web

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 576ff4e546e3301ce474deef9345522b7ef3a9d172600c62057f182f3a68c1f6 
 
 build:
-  number: 0 
+  number: 1
   skip: True  # [not unix or not x86]
 
 requirements:
@@ -23,15 +23,26 @@ requirements:
     - pkg-config
     - perl
   host:
-    - openssl
+    - openssl {{ openssl }}
+    - pcre 8.45
+    - zlib {{ zlib }}
+  run:
+    - openssl 3.*
     - pcre
     - zlib
 
 about:
-    home: http://openresty.org
-    license: BSD-3 
+    home: https://openresty.org/
+    license: BSD-3-Clause
     license_family: BSD 
     license_file: COPYRIGHT
+    summary: OpenResty® is a dynamic web platform based on NGINX and LuaJIT.
+    description: >
+      OpenResty® is a full-fledged web platform that integrates our enhanced version
+      of the Nginx core, our enhanced version of LuaJIT, many carefully written Lua
+      libraries, lots of high quality 3rd-party Nginx modules, and most of their external
+      dependencies. It is designed to help developers easily build scalable web
+      applications, web services, and dynamic web gateways.
     doc_url: https://github.com/openresty/openresty/blob/master/README.markdown 
     dev_url: https://github.com/openresty/openresty
 


### PR DESCRIPTION
Rebuild with OpenSSL 3. Note that this version doesn't officially support OpenSSL 3, but it compiles correctly (with some OpenSSL 3 related deprecation warnings that are harmless).