### PR TITLE
Force a rebuild. The previous PR did not trigger a build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pkg-config
     - perl
   host:
-    - openssl {{ openssl }}
+    - openssl 3.0.8
     - pcre 8.45
     - zlib {{ zlib }}
   run:


### PR DESCRIPTION
https://github.com/AnacondaRecipes/openresty-feedstock/pull/2 was merged with "skip ci"